### PR TITLE
Include all blocks and items up to release 1.5.2

### DIFF
--- a/minecraft/blocks_and_items.md
+++ b/minecraft/blocks_and_items.md
@@ -156,7 +156,7 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 151 | Daylight Sensor | tile.daylightDetector | 1.5 (13w01a) |
 | 152 | Block of Redstone | tile.blockRedstone | 1.5 (13w01a) |
 | 153 | Nether Quartz Ore | tile.netherquartz | 1.5 (13w01a) |
-| 154 | Hopper | tile.Hopper | 1.5 (13w01a) |
+| 154 | Hopper | tile.hopper | 1.5 (13w01a) |
 | 155 | Block of Quartz | tile.quartzBlock | 1.5 (13w02a) |
 | 156 | Quartz Stairs | tile.stairsQuartz | 1.5 (13w02a) |
 | 157 | Activator Rail | tile.activatorRail | 1.5 (13w02a) |
@@ -167,116 +167,116 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 > In vanilla, item IDs are always shifted up by 256 when they are registered. (e.g. `20` -> `276`)
 > This way, blocks and items can share the same ID system.
 
-| ID | Item | Translation key |
-| --- | --- | --- |
-| 256 | Iron Shovel | item.shovelIron |
-| 257 | Iron Pickaxe | item.pickaxeIron |
-| 258 | Iron Axe | item.hatchetIron |
-| 259 | Flint and Steel | item.flintAndSteel |
-| 260 | Apple | item.apple |
-| 261 | Bow | item.bow |
-| 262 | Arrow | item.arrow |
-| 263 | Coal | item.coal |
-| 264 | Diamond | item.emerald[^1] |
-| 265 | Iron Ingot | item.ingotIron |
-| 266 | Gold Ingot | item.ingotGold |
-| 267 | Iron Sword | item.swordIron |
-| 268 | Wooden Sword | item.swordWood |
-| 269 | Wooden Shovel | item.shovelWood |
-| 270 | Wooden Pickaxe | item.pickaxeWood |
-| 271 | Wooden Axe | item.hatchetWood |
-| 272 | Stone Sword | item.swordStone |
-| 273 | Stone Shovel | item.shovelStone |
-| 274 | Stone Pickaxe | item.pickaxeStone |
-| 275 | Stone Axe | item.hatchetStone |
-| 276 | Diamond Sword | item.swordDiamond |
-| 277 | Diamond Shovel | item.shovelDiamond |
-| 278 | Diamond Pickaxe | item.pickaxeDiamond |
-| 279 | Diamond Axe | item.hatchetDiamond |
-| 280 | Stick | item.stick |
-| 281 | Bowl | item.bowl |
-| 282 | Mushroom Stew | item.mushroomStew |
-| 283 | Golden Sword | item.swordGold |
-| 284 | Golden Shovel | item.shovelGold |
-| 285 | Golden Pickaxe | item.pickaxeGold |
-| 286 | Golden Axe | item.hatchetGold |
-| 287 | String | item.string |
-| 288 | Feather | item.feather |
-| 289 | Gunpowder | item.sulphur |
-| 290 | Wooden Hoe | item.hoeWood |
-| 291 | Stone Hoe | item.hoeStone |
-| 292 | Iron Hoe | item.hoeIron |
-| 293 | Diamond Hoe | item.hoeDiamond |
-| 294 | Golden Hoe | item.hoeGold |
-| 295 | Seeds | item.seeds |
-| 296 | Wheat | item.wheat |
-| 297 | Bread | item.bread |
-| 298 | Leather Cap | item.helmetCloth |
-| 299 | Leather Tunic | item.chestplateCloth |
-| 300 | Leather Pants | item.leggingsCloth |
-| 301 | Leather Boots | item.bootsCloth |
-| 302 | Chain Helmet | item.helmetChain |
-| 303 | Chain Chestplate | item.chestplateChain |
-| 304 | Chain Leggings | item.leggingsChain |
-| 305 | Chain Boots | item.bootsChain |
-| 306 | Iron Helmet | item.helmetIron |
-| 307 | Iron Chestplate | item.chestplateIron |
-| 308 | Iron Leggings | item.leggingsIron |
-| 309 | Iron Boots | item.bootsIron |
-| 310 | Diamond Helmet | item.helmetDiamond |
-| 311 | Diamond Chestplate | item.chestplateDiamond |
-| 312 | Diamond Leggings | item.leggingsDiamond |
-| 313 | Diamond Boots | item.bootsDiamond |
-| 314 | Golden Helmet | item.helmetGold |
-| 315 | Golden Chestplate | item.chestplateGold |
-| 316 | Golden Leggings | item.leggingsGold |
-| 317 | Golden boots | item.bootsGold |
-| 318 | Flint | item.flint |
-| 319 | Raw Porkchop | item.porkchopRaw |
-| 320 | Cooked Porkchop | item.porkchopCooked |
-| 321 | Painting | item.painting |
-| 322 | Golden Apple | item.appleGold |
-| 323 | Sign | item.sign |
-| 324 | Wooden Door | item.doorWood |
-| 325 | Bucket | item.bucket |
-| 326 | Water Bucket | item.bucketWater |
-| 327 | Lava bucket | item.bucketLava |
-| 328 | Minecart | item.minecart |
-| 329 | Saddle | item.saddle |
-| 330 | Iron Door | item.doorIron |
-| 331 | Redstone | item.redstone |
-| 332 | Snowball | item.snowball |
-| 333 | Boat | item.boat |
-| 334 | Leather | item.leather |
-| 335 | Milk | item.milk |
-| 336 | Brick | item.brick |
-| 337 | Clay | item.clay |
-| 338 | Sugar Canes | item.reeds |
-| 339 | Paper | item.paper |
-| 340 | Book | item.book |
-| 341 | Slimeball | item.slimeball |
-| 342 | Minecart with Chest | item.minecartChest |
-| 343 | Minecart with Furnace | item.minecartFurnace |
-| 344 | Egg | item.egg |
-| 345 | Compass | item.compass |
-| 346 | Fishing Rod | item.fishingRod |
-| 347 | Clock | item.clock |
-| 348 | Glowstone Dust | item.yellowDust |
-| 349 | Raw Fish | item.fishRaw |
-| 350 | Cooked Fish | item.fishCooked |
-| 351 | Dye | item.dyePowder |
-| 352 | Bone | item.bone |
-| 353 | Sugar | item.sugar |
-| 354 | Cake | item.cake |
-| 355 | Bed | item.bed |
-| 356 | Redstone Repeater | item.diode |
-| 357 | Cookie | item.cookie |
-| 358 | Map | item.map |
-| 359 | Shears | item.shears |
-| 2256 | Music Disc (C418 - 13) | item.record |
-| 2257 | Music Disc (C418 - cat) | item.record |
+| ID | Item | Translation key | Introduced in |
+| --- | --- | --- | --- |
+| 256 | Iron Shovel | item.shovelIron | Indev 20091231-2 |
+| 257 | Iron Pickaxe | item.pickaxeIron | Indev 20100110 |
+| 258 | Iron Axe | item.hatchetIron | Indev 20100110 |
+| 259 | Flint and Steel | item.flintAndSteel | Indev 20100110 |
+| 260 | Apple | item.apple | Indev 20091231-2 |
+| 261 | Bow | item.bow | Indev 20100110 |
+| 262 | Arrow | item.arrow | Indev 20100122 |
+| 263 | Coal | item.coal | Indev 20100128 |
+| 264 | Diamond | item.emerald[^1] | Indev 20100128 |
+| 265 | Iron Ingot | item.ingotIron | Indev 20100128 |
+| 266 | Gold Ingot | item.ingotGold | Indev 20100128 |
+| 267 | Iron Sword | item.swordIron | Indev 20091231-2 |
+| 268 | Wooden Sword | item.swordWood | Indev 20100128 |
+| 269 | Wooden Shovel | item.shovelWood | Indev 20100128 |
+| 270 | Wooden Pickaxe | item.pickaxeWood | Indev 20100128 |
+| 271 | Wooden Axe | item.hatchetWood | Indev 20100128 |
+| 272 | Stone Sword | item.swordStone | Indev 20100128 |
+| 273 | Stone Shovel | item.shovelStone | Indev 20100128 |
+| 274 | Stone Pickaxe | item.pickaxeStone | Indev 20100128 |
+| 275 | Stone Axe | item.hatchetStone | Indev 20100128 |
+| 276 | Diamond Sword | item.swordDiamond | Indev 20100128 |
+| 277 | Diamond Shovel | item.shovelDiamond | Indev 20100128 |
+| 278 | Diamond Pickaxe | item.pickaxeDiamond | Indev 20100128 |
+| 279 | Diamond Axe | item.hatchetDiamond | Indev 20100128 |
+| 280 | Stick | item.stick | Indev 20100129 |
+| 281 | Bowl | item.bowl | Indev 20100130 |
+| 282 | Mushroom Stew | item.mushroomStew | Indev 20100130 |
+| 283 | Golden Sword | item.swordGold | Indev 20100130 |
+| 284 | Golden Shovel | item.shovelGold | Indev 20100130 |
+| 285 | Golden Pickaxe | item.pickaxeGold | Indev 20100130 |
+| 286 | Golden Axe | item.hatchetGold | Indev 20100130 |
+| 287 | String | item.string | Indev 20100130 |
+| 288 | Feather | item.feather | Indev 20100130 |
+| 289 | Gunpowder | item.sulphur | Indev 20100130 |
+| 290 | Wooden Hoe | item.hoeWood | Indev 20100206 |
+| 291 | Stone Hoe | item.hoeStone | Indev 20100206 |
+| 292 | Iron Hoe | item.hoeIron | Indev 20100206 |
+| 293 | Diamond Hoe | item.hoeDiamond | Indev 20100206 |
+| 294 | Golden Hoe | item.hoeGold | Indev 20100206 |
+| 295 | Seeds | item.seeds | Indev 20100206 |
+| 296 | Wheat | item.wheat | Indev 20100206 |
+| 297 | Bread | item.bread | Indev 20100206 |
+| 298 | Leather Cap | item.helmetCloth | Indev 20091231-2 |
+| 299 | Leather Tunic | item.chestplateCloth | Indev 20091231-2 |
+| 300 | Leather Pants | item.leggingsCloth | Indev 20091231-2 |
+| 301 | Leather Boots | item.bootsCloth | Indev 20091231-2 |
+| 302 | Chain Helmet | item.helmetChain | Indev 20091231-2 |
+| 303 | Chain Chestplate | item.chestplateChain | Indev 20091231-2 |
+| 304 | Chain Leggings | item.leggingsChain | Indev 20091231-2 |
+| 305 | Chain Boots | item.bootsChain | Indev 20091231-2 |
+| 306 | Iron Helmet | item.helmetIron | Indev 20091231-2 |
+| 307 | Iron Chestplate | item.chestplateIron | Indev 20091231-2 |
+| 308 | Iron Leggings | item.leggingsIron | Indev 20091231-2 |
+| 309 | Iron Boots | item.bootsIron | Indev 20091231-2 |
+| 310 | Diamond Helmet | item.helmetDiamond | Indev 20100212-1 |
+| 311 | Diamond Chestplate | item.chestplateDiamond | Indev 20100212-1 |
+| 312 | Diamond Leggings | item.leggingsDiamond | Indev 20100212-1 |
+| 313 | Diamond Boots | item.bootsDiamond | Indev 20100212-1 |
+| 314 | Golden Helmet | item.helmetGold | Indev 20100212-1 |
+| 315 | Golden Chestplate | item.chestplateGold | Indev 20100212-1 |
+| 316 | Golden Leggings | item.leggingsGold | Indev 20100212-1 |
+| 317 | Golden Boots | item.bootsGold | Indev 20100212-1 |
+| 318 | Flint | item.flint | Indev 20100219 |
+| 319 | Raw Porkchop | item.porkchopRaw | Indev 20100219 |
+| 320 | Cooked Porkchop | item.porkchopCooked | Indev 20100219 |
+| 321 | Painting | item.painting | Indev 20100223 |
+| 322 | Golden Apple | item.appleGold | Infdev 20100227-1 |
+| 323 | Sign | item.sign | Infdev 20100607 |
+| 324 | Wooden Door | item.doorWood | Infdev 20100607 |
+| 325 | Bucket | item.bucket | Infdev 20100615 |
+| 326 | Water Bucket | item.bucketWater | Infdev 20100615 |
+| 327 | Lava Bucket | item.bucketLava | Infdev 20100615 |
+| 328 | Minecart | item.minecart | Infdev 20100618 |
+| 329 | Saddle | item.saddle | Infdev 20100625-2 |
+| 330 | Iron Door | item.doorIron | Alpha v1.0.1 |
+| 331 | Redstone | item.redstone | Alpha v1.0.1 |
+| 332 | Snowball | item.snowball | Alpha v1.0.5 |
+| 333 | Boat | item.boat | Alpha v1.0.6 |
+| 334 | Leather | item.leather | Alpha v1.0.8 |
+| 335 | Milk | item.milk | Alpha v1.0.8 |
+| 336 | Brick | item.brick | Alpha v1.0.11 |
+| 337 | Clay | item.clay | Alpha v1.0.11 |
+| 338 | Sugar Canes | item.reeds | Alpha v1.0.11 |
+| 339 | Paper | item.paper | Alpha v1.0.11 |
+| 340 | Book | item.book | Alpha v1.0.11 |
+| 341 | Slimeball | item.slimeball | Alpha v1.0.11 |
+| 342 | Minecart with Chest | item.minecartChest | Alpha v1.0.14 |
+| 343 | Minecart with Furnace | item.minecartFurnace | Alpha v1.0.14 |
+| 344 | Egg | item.egg | Alpha v1.0.14 |
+| 345 | Compass | item.compass | Alpha v1.1.0 |
+| 346 | Fishing Rod | item.fishingRod | Alpha v1.1.1 |
+| 347 | Clock | item.clock | Alpha v1.2.0 |
+| 348 | Glowstone Dust | item.yellowDust | Alpha v1.2.0 |
+| 349 | Raw Fish | item.fishRaw | Alpha v1.2.0 |
+| 350 | Cooked Fish | item.fishCooked | Alpha v1.2.0 |
+| 351 | Dye | item.dyePowder | Beta 1.2 |
+| 352 | Bone | item.bone | Beta 1.2 |
+| 353 | Sugar | item.sugar | Beta 1.2 |
+| 354 | Cake | item.cake | Beta 1.2 |
+| 355 | Bed | item.bed | Beta 1.3 |
+| 356 | Redstone Repeater | item.diode | Beta 1.3 |
+| 357 | Cookie | item.cookie | Beta 1.4 |
+| 358 | Map | item.map | Beta 1.6 |
+| 359 | Shears | item.shears | Beta 1.7 |
+| 2256 | Music Disc (C418 - 13) | item.record | Alpha v1.0.14 |
+| 2257 | Music Disc (C418 - cat) | item.record | Alpha v1.0.14 |
 
-[^1]: In Release 1.3.1 and onward, item.diamond.
+[^1]: From Release 1.3.1 onward, the translation key for diamonds is `item.diamond`.
 
 ## Removed blocks
 | ID | Block | Introduced in | Removed in |

--- a/minecraft/blocks_and_items.md
+++ b/minecraft/blocks_and_items.md
@@ -44,8 +44,8 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 38 | Rose | tile.rose | 0.0.20a |
 | 39 | Brown Mushroom | tile.mushroom | 0.0.20a |
 | 40 | Red Mushroom | tile.mushroom | 0.0.20a |
-| 41 | Gold Block | tile.blockGold | 0.0.20a |
-| 42 | Iron Block | tile.blockIron | 0.26 SURVIVAL TEST |
+| 41 | Block of Gold | tile.blockGold | 0.0.20a |
+| 42 | Block of Iron | tile.blockIron | 0.26 SURVIVAL TEST |
 | 43 | Double Slab | tile.stoneSlab | 0.26 SURVIVAL TEST |
 | 44 | Slab | tile.stoneSlab | 0.26 SURVIVAL TEST |
 | 45 | Bricks | tile.brick | 0.26 SURVIVAL TEST |
@@ -60,7 +60,7 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 54 | Chest | tile.chest | Indev 20100124 |
 | 55 | Redstone Dust | tile.redstoneDust | Alpha v1.0.1 |
 | 56 | Diamond Ore | tile.oreDiamond | Indev 20100128 |
-| 57 | Diamond Block | tile.blockDiamond | Indev 20100128 |
+| 57 | Block of Diamond | tile.blockDiamond | Indev 20100128 |
 | 58 | Crafting Table | tile.workbench | Indev 20100130 |
 | 59 | Crops | tile.crops | Indev 20100206 |
 | 60 | Farmland | tile.farmland | Indev 20100206 |
@@ -112,6 +112,55 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 107 | Fence Gate | tile.fenceGate | Beta 1.8 |
 | 108 | Brick Stairs | tile.stairsBrick | Beta 1.8 |
 | 109 | Stone Brick Stairs | tile.stairsStoneBrickSmooth | Beta 1.8 |
+| 110 | Mycelium | tile.mycel | 1.0.0 (Beta 1.9 Prerelease) |
+| 111 | Lily Pad | tile.waterlily | 1.0.0 (Beta 1.9 Prerelease) |
+| 112 | Nether Brick | tile.netherBrick | 1.0.0 (Beta 1.9 Prerelease) |
+| 113 | Nether Brick Fence | tile.netherFence | 1.0.0 (Beta 1.9 Prerelease) |
+| 114 | Nether Brick Stairs | tile.stairsNetherBrick | 1.0.0 (Beta 1.9 Prerelease) |
+| 115 | Nether Wart | tile.netherStalk | 1.0.0 (Beta 1.9 Prerelease) |
+| 116 | Enchantment Table | tile.enchantmentTable | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 117 | Brewing Stand | tile.brewingStand | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 118 | Cauldron | tile.cauldron | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 119 | End Portal | N/A | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 120 | End Portal Frame | tile.endPortalFrame | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 121 | End Stone | tile.whiteStone | 1.0.0 (Beta 1.9 Prerelease 4) |
+| 122 | Dragon Egg | tile.dragonEgg | 1.0.0 (Beta 1.9 Prerelease 6) |
+| 123 | Redstone Lamp | tile.redstoneLight | 1.2.1 (12w07a) |
+| 124 | Active Redstone Lamp | tile.redstoneLight | 1.2.1 (12w07a) |
+| 125 | Double Wood Slab | tile.woodSlab | 1.3.1 (12w17a) |
+| 126 | Wood Slab | tile.woodSlab | 1.3.1 (12w17a) |
+| 127 | Cocoa | tile.cocoa | 1.3.1 (12w19a) |
+| 128 | Sandstone Stairs | tile.stairsSandStone | 1.3.1 (12w21a) |
+| 129 | Emerald Ore | tile.oreEmerald | 1.3.1 (12w21a) |
+| 130 | Ender Chest | tile.Ender Chest | 1.3.1 (12w21a) |
+| 131 | Tripwire Hook | tile.tripWireSource | 1.3.1 (12w22a) |
+| 132 | Tripwire | tile.tripWire | 1.3.1 (12w22a) |
+| 133 | Emerald Block | tile.blockEmerald | 1.3.1 (12w22a) |
+| 134 | Spruce Wood Stairs | tile.stairsWoodSpruce | 1.3.1 (12w25a) |
+| 135 | Birch Wood Stairs | tile.stairsWoodBirch | 1.3.1 (12w25a) |
+| 136 | Jungle Wood Stairs | tile.stairsWoodJungle | 1.3.1 (12w25a) |
+| 137 | Command Block | tile.commandBlock | 1.4.2 (12w32a) |
+| 138 | Beacon | tile.beacon | 1.4.2 (12w32a) |
+| 139 | Cobblestone Wall | tile.cobbleWall | 1.4.2 (12w34a) |
+| 140 | Flower Pot | tile.flowerPot | 1.4.2 (12w34a) |
+| 141 | Carrots | tile.carrots | 1.4.2 (12w34a) |
+| 142 | Potatoes | tile.potatoes | 1.4.2 (12w34a) |
+| 143 | Wooden Button | tile.button | 1.4.2 (12w34a) |
+| 144 | Mob Head | tile.skull | 1.4.2 (12w36a) |
+| 145 | Anvil | tile.anvil | 1.4.2 (12w41a) |
+| 146 | Trapped Chest | tile.chestTrap | 1.5 (13w01a) |
+| 147 | Weighted Pressure Plate (Light) | tile.weightedPlate_light | 1.5 (13w01a) |
+| 148 | Weighted Pressure Plate (Heavy) | tile.weightedPlate_heavy | 1.5 (13w01a) |
+| 149 | Redstone Comparator | tile.comparator | 1.5 (13w01a) |
+| 150 | Active Redstone Comparator | tile.comparator | 1.5 (13w01a) |
+| 151 | Daylight Sensor | tile.daylightDetector | 1.5 (13w01a) |
+| 152 | Block of Redstone | tile.blockRedstone | 1.5 (13w01a) |
+| 153 | Nether Quartz Ore | tile.netherquartz | 1.5 (13w01a) |
+| 154 | Hopper | tile.Hopper | 1.5 (13w01a) |
+| 155 | Block of Quartz | tile.quartzBlock | 1.5 (13w02a) |
+| 156 | Quartz Stairs | tile.stairsQuartz | 1.5 (13w02a) |
+| 157 | Activator Rail | tile.activatorRail | 1.5 (13w02a) |
+| 158 | Dropper | tile.dropper | 1.5 (13w03a) |
 
 ## Items
 > [!NOTE]
@@ -128,7 +177,7 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 261 | Bow | item.bow |
 | 262 | Arrow | item.arrow |
 | 263 | Coal | item.coal |
-| 264 | Diamond | item.emerald |
+| 264 | Diamond | item.emerald[^1] |
 | 265 | Iron Ingot | item.ingotIron |
 | 266 | Gold Ingot | item.ingotGold |
 | 267 | Iron Sword | item.swordIron |
@@ -226,6 +275,8 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 359 | Shears | item.shears |
 | 2256 | Music Disc (C418 - 13) | item.record |
 | 2257 | Music Disc (C418 - cat) | item.record |
+
+[^1]: In Release 1.3.1 and onward, item.diamond.
 
 ## Removed blocks
 | ID | Block | Introduced in | Removed in |

--- a/minecraft/blocks_and_items.md
+++ b/minecraft/blocks_and_items.md
@@ -1,104 +1,117 @@
 # Block and Item Reference
-This is a general reference for block and item IDs in vanilla Minecraft Beta 1.7.3.
+This is a general reference for block and item IDs in vanilla Minecraft up to Release 1.5.2.
 
 ## Blocks
-| ID | Block | Translation key |
-| --- | --- | --- |
-| 1 | Stone | tile.stone |
-| 2 | Grass | tile.grass |
-| 3 | Dirt | tile.dirt |
-| 4 | Cobblestone | tile.stonebrick |
-| 5 | Wooden Planks | tile.wood |
-| 6 | Sapling | tile.sapling |
-| 7 | Bedrock | tile.bedrock |
-| 8 | Flowing Water | tile.water |
-| 9 | Water | tile.water |
-| 10 | Flowing Lava | tile.lava |
-| 11 | Lava | tile.lava |
-| 12 | Sand | tile.sand |
-| 13 | Gravel | tile.gravel |
-| 14 | Gold Ore | tile.oreGold |
-| 15 | Iron Ore | tile.oreIron |
-| 16 | Coal Ore | tile.oreCoal |
-| 17 | Log | tile.log |
-| 18 | Leaves | tile.leaves |
-| 19 | Sponge | tile.sponge |
-| 20 | Glass | tile.glass |
-| 21 | Lapis Ore | tile.oreLapis |
-| 22 | Lapis Block | tile.blockLapis |
-| 23 | Dispenser | tile.dispenser |
-| 24 | Sandstone | tile.sandStone |
-| 25 | Note Block | tile.musicBlock |
-| 26 | Bed | tile.bed |
-| 27 | Powered Rail | tile.goldenRail |
-| 28 | Detector Rail | tile.detectorRail |
-| 29 | Sticky Piston Base | tile.pistonStickyBase |
-| 30 | Cobweb | tile.web |
-| 31 | Tall Grass | tile.tallgrass |
-| 32 | Dead Bush | tile.deadbush |
-| 33 | Piston Base | tile.pistonBase |
-| 34 | Piston Extension | N/A |
-| 35 | Wool | tile.cloth |
-| 36 | Moving Block | N/A |
-| 37 | Dandelion | tile.flower |
-| 38 | Rose | tile.rose |
-| 39 | Brown Mushroom | tile.mushroom |
-| 40 | Red Mushroom | tile.mushroom |
-| 41 | Gold Block | tile.blockGold |
-| 42 | Iron Block | tile.blockIron |
-| 43 | Double Slab | tile.stoneSlab |
-| 44 | Slab | tile.stoneSlab |
-| 45 | Bricks | tile.brick |
-| 46 | TNT | tile.tnt |
-| 47 | Bookshelf | tile.bookshelf |
-| 48 | Moss Stone | tile.stoneMoss |
-| 49 | Obsidian | tile.obsidian |
-| 50 | Torch | tile.torch |
-| 51 | Fire | tile.fire |
-| 52 | Mob Spawner | tile.mobSpawner |
-| 53 | Wooden Stairs | tile.stairsWood |
-| 54 | Chest | tile.chest |
-| 55 | Redstone Dust | tile.redstoneDust |
-| 56 | Diamond Ore | tile.oreDiamond |
-| 57 | Diamond Block | tile.blockDiamond |
-| 58 | Crafting Table | tile.workbench |
-| 59 | Crops | tile.crops |
-| 60 | Farmland | tile.farmland |
-| 61 | Furnace | tile.furnace |
-| 62 | Active Furnace | tile.furnace |
-| 63 | Sign | tile.sign |
-| 64 | Wooden Door | tile.doorWood |
-| 65 | Ladder | tile.ladder |
-| 66 | Rail | tile.rail |
-| 67 | Cobblestone Stairs | tile.stairsStone |
-| 68 | Wall Sign | tile.sign |
-| 69 | Lever | tile.lever |
-| 70 | Stone Pressure Plate | tile.pressurePlate |
-| 71 | Iron Door | tile.doorIron |
-| 72 | Wooden Pressure Plate | tile.pressurePlate |
-| 73 | Redstone Ore | tile.oreRedstone |
-| 74 | Lit Redstone Ore | tile.oreRedstone |
-| 75 | Redstone Torch | tile.notGate |
-| 76 | Lit Redstone Torch | tile.notGate |
-| 77 | Button | tile.button |
-| 78 | Snow | tile.snow |
-| 79 | Ice | tile.ice |
-| 80 | Snow Block | tile.snow |
-| 81 | Cactus | tile.cactus |
-| 82 | Clay | tile.clay |
-| 83 | Sugar cane | tile.reeds |
-| 84 | Jukebox | tile.jukebox |
-| 85 | Fence | tile.fence |
-| 86 | Pumpkin | tile.pumpkin |
-| 87 | Netherrack | tile.hellrock |
-| 89 | Glowstone | tile.lightgem |
-| 90 | Portal | tile.portal |
-| 91 | Jack 'o' Lantern | tile.litpumpkin |
-| 92 | Cake | tile.cake |
-| 93 | Redstone Repeater | tile.diode |
-| 94 | Active Redstone Repeater | tile.diode |
-| 95 | Locked Chest | tile.lockedchest |
-| 96 | Trapdoor | tile.trapdoor |
+| ID | Block | Translation key | Introduced in |
+| --- | --- | --- | --- |
+| 1 | Stone | tile.stone | rd-132211 |
+| 2 | Grass | tile.grass | rd-132211 |
+| 3 | Dirt | tile.dirt | rd-20090515 |
+| 4 | Cobblestone | tile.stonebrick | rd-20090515 |
+| 5 | Wooden Planks | tile.wood | rd-20090515 |
+| 6 | Sapling | tile.sapling | rd-20090515 |
+| 7 | Bedrock | tile.bedrock | 0.0.12a |
+| 8 | Flowing Water | tile.water | 0.0.12a |
+| 9 | Water | tile.water | 0.0.12a |
+| 10 | Flowing Lava | tile.lava | 0.0.12a |
+| 11 | Lava | tile.lava | 0.0.12a |
+| 12 | Sand | tile.sand | 0.0.14a |
+| 13 | Gravel | tile.gravel | 0.0.14a |
+| 14 | Gold Ore | tile.oreGold | 0.0.14a |
+| 15 | Iron Ore | tile.oreIron | 0.0.14a |
+| 16 | Coal Ore | tile.oreCoal | 0.0.14a |
+| 17 | Log | tile.log | 0.0.14a |
+| 18 | Leaves | tile.leaves | 0.0.14a |
+| 19 | Sponge | tile.sponge | 0.0.19a |
+| 20 | Glass | tile.glass | 0.0.19a |
+| 21 | Lapis Ore | tile.oreLapis | Beta 1.2 |
+| 22 | Lapis Block | tile.blockLapis | Beta 1.2 |
+| 23 | Dispenser | tile.dispenser | Beta 1.2 |
+| 24 | Sandstone | tile.sandStone | Beta 1.2 |
+| 25 | Note Block | tile.musicBlock | Beta 1.2 |
+| 26 | Bed | tile.bed | Beta 1.3 |
+| 27 | Powered Rail | tile.goldenRail | Beta 1.5 |
+| 28 | Detector Rail | tile.detectorRail | Beta 1.5 |
+| 29 | Sticky Piston Base | tile.pistonStickyBase | Beta 1.7 |
+| 30 | Cobweb | tile.web | Beta 1.5 |
+| 31 | Tall Grass | tile.tallgrass | Beta 1.6 |
+| 32 | Dead Bush | tile.deadbush | Beta 1.6 |
+| 33 | Piston Base | tile.pistonBase | Beta 1.7 |
+| 34 | Piston Extension | N/A | Beta 1.7 |
+| 35 | Wool | tile.cloth | 0.0.20a |
+| 36 | Moving Block | N/A | Beta 1.7 |
+| 37 | Dandelion | tile.flower | 0.0.20a |
+| 38 | Rose | tile.rose | 0.0.20a |
+| 39 | Brown Mushroom | tile.mushroom | 0.0.20a |
+| 40 | Red Mushroom | tile.mushroom | 0.0.20a |
+| 41 | Gold Block | tile.blockGold | 0.0.20a |
+| 42 | Iron Block | tile.blockIron | 0.26 SURVIVAL TEST |
+| 43 | Double Slab | tile.stoneSlab | 0.26 SURVIVAL TEST |
+| 44 | Slab | tile.stoneSlab | 0.26 SURVIVAL TEST |
+| 45 | Bricks | tile.brick | 0.26 SURVIVAL TEST |
+| 46 | TNT | tile.tnt | 0.26 SURVIVAL TEST |
+| 47 | Bookshelf | tile.bookshelf | 0.26 SURVIVAL TEST |
+| 48 | Moss Stone | tile.stoneMoss | 0.26 SURVIVAL TEST |
+| 49 | Obsidian | tile.obsidian | 0.28 |
+| 50 | Torch | tile.torch | Indev 20091223-1 |
+| 51 | Fire | tile.fire | Indev 20100109 |
+| 52 | Monster Spawner | tile.mobSpawner | Infdev 20100625-2 |
+| 53 | Wooden Stairs | tile.stairsWood | Infdev 20100629 |
+| 54 | Chest | tile.chest | Indev 20100124 |
+| 55 | Redstone Dust | tile.redstoneDust | Alpha v1.0.1 |
+| 56 | Diamond Ore | tile.oreDiamond | Indev 20100128 |
+| 57 | Diamond Block | tile.blockDiamond | Indev 20100128 |
+| 58 | Crafting Table | tile.workbench | Indev 20100130 |
+| 59 | Crops | tile.crops | Indev 20100206 |
+| 60 | Farmland | tile.farmland | Indev 20100206 |
+| 61 | Furnace | tile.furnace | Indev 20100219 |
+| 62 | Active Furnace | tile.furnace | Indev 20100219 |
+| 63 | Sign | tile.sign | Infdev 20100607 |
+| 64 | Wooden Door | tile.doorWood | Infdev 20100607 |
+| 65 | Ladder | tile.ladder | Infdev 20100607 |
+| 66 | Rail | tile.rail | Infdev 20100618 |
+| 67 | Cobblestone Stairs | tile.stairsStone | Infdev 20100629 |
+| 68 | Wall Sign | tile.sign | Alpha v1.0.1 |
+| 69 | Lever | tile.lever | Alpha v1.0.1 |
+| 70 | Stone Pressure Plate | tile.pressurePlate | Alpha v1.0.1 |
+| 71 | Iron Door | tile.doorIron | Alpha v1.0.1 |
+| 72 | Wooden Pressure Plate | tile.pressurePlate | Alpha v1.0.1 |
+| 73 | Redstone Ore | tile.oreRedstone | Alpha v1.0.1 |
+| 74 | Lit Redstone Ore | tile.oreRedstone | Alpha v1.0.1 |
+| 75 | Redstone Torch | tile.notGate | Alpha v1.0.1 |
+| 76 | Lit Redstone Torch | tile.notGate | Alpha v1.0.1 |
+| 77 | Button | tile.button | Alpha v1.0.1 |
+| 78 | Snow | tile.snow | Alpha v1.0.4 |
+| 79 | Ice | tile.ice | Alpha v1.0.4 |
+| 80 | Snow Block | tile.snow | Alpha v1.0.5 |
+| 81 | Cactus | tile.cactus | Alpha v1.0.6 |
+| 82 | Clay | tile.clay | Alpha v1.0.11 |
+| 83 | Sugar cane | tile.reeds | Alpha v1.0.11 |
+| 84 | Jukebox | tile.jukebox | Alpha v1.0.14 |
+| 85 | Fence | tile.fence | Alpha v1.0.17 |
+| 86 | Pumpkin | tile.pumpkin | Alpha v1.2.0 |
+| 87 | Netherrack | tile.hellrock | Alpha v1.2.0 |
+| 89 | Glowstone | tile.lightgem | Alpha v1.2.0 |
+| 90 | Portal | tile.portal | Alpha v1.2.0 |
+| 91 | Jack 'o' Lantern | tile.litpumpkin | Alpha v1.2.0 |
+| 92 | Cake | tile.cake | Beta 1.2 |
+| 93 | Redstone Repeater | tile.diode | Beta 1.3 |
+| 94 | Active Redstone Repeater | tile.diode | Beta 1.3 |
+| 95 | Locked Chest | tile.lockedchest | Beta 1.4 |
+| 96 | Trapdoor | tile.trapdoor | Beta 1.6 |
+| 97 | Monster Egg | tile.monsterStoneEgg | Beta 1.8 |
+| 98 | Stone Bricks | tile.stonebricksmooth | Beta 1.8 |
+| 99 | Brown Mushroom Block | tile.mushroom | Beta 1.8 |
+| 100 | Red Mushroom Block | tile.mushroom | Beta 1.8 |
+| 101 | Iron Bars | tile.fenceIron | Beta 1.8 |
+| 102 | Glass Pane | tile.thinGlass | Beta 1.8 |
+| 103 | Melon Block | tile.melon | Beta 1.8 |
+| 104 | Pumpkin Stem | N/A | Beta 1.8 |
+| 105 | Melon Stem | N/A | Beta 1.8 |
+| 106 | Vines | tile.vine | Beta 1.8 |
+| 107 | Fence Gate | tile.fenceGate | Beta 1.8 |
+| 108 | Brick Stairs | tile.stairsBrick | Beta 1.8 |
+| 109 | Stone Brick Stairs | tile.stairsStoneBrickSmooth | Beta 1.8 |
 
 ## Items
 > [!NOTE]
@@ -128,9 +141,9 @@ This is a general reference for block and item IDs in vanilla Minecraft Beta 1.7
 | 274 | Stone Pickaxe | item.pickaxeStone |
 | 275 | Stone Axe | item.hatchetStone |
 | 276 | Diamond Sword | item.swordDiamond |
-| 277 |  Diamond Shovel | item.shovelDiamond |
-| 278 |  Diamond Pickaxe | item.pickaxeDiamond |
-| 279 |  Diamond Axe | item.hatchetDiamond |
+| 277 | Diamond Shovel | item.shovelDiamond |
+| 278 | Diamond Pickaxe | item.pickaxeDiamond |
+| 279 | Diamond Axe | item.hatchetDiamond |
 | 280 | Stick | item.stick |
 | 281 | Bowl | item.bowl |
 | 282 | Mushroom Stew | item.mushroomStew |
@@ -139,7 +152,7 @@ This is a general reference for block and item IDs in vanilla Minecraft Beta 1.7
 | 285 | Golden Pickaxe | item.pickaxeGold |
 | 286 | Golden Axe | item.hatchetGold |
 | 287 | String | item.string |
-| 288 |  Feather | item.feather |
+| 288 | Feather | item.feather |
 | 289 | Gunpowder | item.sulphur |
 | 290 | Wooden Hoe | item.hoeWood |
 | 291 | Stone Hoe | item.hoeStone |
@@ -213,3 +226,25 @@ This is a general reference for block and item IDs in vanilla Minecraft Beta 1.7
 | 359 | Shears | item.shears |
 | 2256 | Music Disc (C418 - 13) | item.record |
 | 2257 | Music Disc (C418 - cat) | item.record |
+
+## Removed blocks
+| ID | Block | Introduced in | Removed in |
+| --- | --- | --- | --- |
+| 21 | Red Cloth | 0.0.20a | Infdev 20100624 |
+| 22 | Orange Cloth | 0.0.20a | Infdev 20100624 |
+| 23 | Yellow Cloth | 0.0.20a | Infdev 20100624 |
+| 24 | Chartruese Cloth | 0.0.20a | Infdev 20100624 |
+| 25 | Green Cloth | 0.0.20a | Infdev 20100624 |
+| 26 | Spring Green Cloth | 0.0.20a | Infdev 20100624 |
+| 27 | Cyan Cloth | 0.0.20a | Infdev 20100624 |
+| 28 | Capri Cloth | 0.0.20a | Infdev 20100624 |
+| 29 | Ultramarine Cloth | 0.0.20a | Infdev 20100624 |
+| 30 | Violet Cloth | 0.0.20a | Infdev 20100624 |
+| 31 | Purple Cloth | 0.0.20a | Infdev 20100624 |
+| 32 | Magenta Cloth | 0.0.20a | Infdev 20100624 |
+| 33 | Rose Cloth | 0.0.20a | Infdev 20100624 |
+| 34 | Dark Gray Cloth | 0.0.20a | Infdev 20100624 |
+| 36 | White Cloth | 0.0.20a | Infdev 20100624 |
+| 52 | Water Spawner | Indev 20100114 | Infdev 20100624 |
+| 53 | Lava Spawner | Indev 20100122 | Infdev 20100624 |
+| 55 | Gear | Indev 20100128 | Alpha v1.0.1 |

--- a/minecraft/blocks_and_items.md
+++ b/minecraft/blocks_and_items.md
@@ -163,9 +163,13 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 158 | Dropper | tile.dropper | 1.5 (13w03a) |
 
 ## Items
+
 > [!NOTE]
 > In vanilla, item IDs are always shifted up by 256 when they are registered. (e.g. `20` -> `276`)
 > This way, blocks and items can share the same ID system.
+
+> [!NOTE]
+> Before Indev 20100110, items were referenced by their index in the item texture atlas rather than by IDs.
 
 | ID | Item | Translation key | Introduced in |
 | --- | --- | --- | --- |
@@ -273,10 +277,69 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 357 | Cookie | item.cookie | Beta 1.4 |
 | 358 | Map | item.map | Beta 1.6 |
 | 359 | Shears | item.shears | Beta 1.7 |
+| 360 | Melon | item.melon | Beta 1.8 |
+| 361 | Pumpkin Seeds | item.seeds_pumpkin | Beta 1.8 |
+| 362 | Melon Seeds | item.seeds_melon | Beta 1.8 |
+| 363 | Raw Beef | item.beefRaw | Beta 1.8 |
+| 364 | Steak | item.beefCooked | Beta 1.8 |
+| 365 | Raw Chicken | item.chickenRaw | Beta 1.8 |
+| 366 | Cooked Chicken | item.chickenCooked | Beta 1.8 |
+| 367 | Rotten Flesh | item.rottenFlesh | Beta 1.8 |
+| 368 | Ender Pearl | item.enderPearl | Beta 1.8 |
+| 369 | Blaze Rod | item.blazeRot | 1.0.0 (Beta 1.9 Prerelease) |
+| 370 | Ghast Tear | item.ghastTear | 1.0.0 (Beta 1.9 Prerelease) |
+| 371 | Gold Nugget | item.goldNugget | 1.0.0 (Beta 1.9 Prerelease) |
+| 372 | Nether Wart | item.netherStalkSeeds | 1.0.0 (Beta 1.9 Prerelease) |
+| 373 | Potion | item.potion | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 374 | Glass Bottle | item.emptyPotion | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 375 | Spider Eye | item.spiderEye | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 376 | Fermented Spider Eye | item.fermentedSpiderEye | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 377 | Blaze Powder | item.blazePowder | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 378 | Magma Cream | item.magmaCream | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 379 | Brewing Stand | item.brewingStand | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 380 | Cauldron | item.cauldron | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 381 | Eye of Ender | item.eyeOfEnder | 1.0.0 (Beta 1.9 Prerelease 3) |
+| 382 | Glistering Melon | item.speckledMelon | 1.0.0 (Beta 1.9 Prerelease 4) |
+| 383 | Spawn Egg | item.monsterPlacer | 1.1 (11w49a) |
+| 384 | Bottle o' Enchanting | item.expBottle | 1.2.1 (12w04a) |
+| 385 | Fire Charge | item.fireball | 1.2.1 (12w04a) |
+| 386 | Book and Quill | item.writingBook | 1.3.1 (12w17a) |
+| 387 | Written Book | item.writtenBook | 1.3.1 (12w17a) |
+| 388 | Emerald | item.emerald | 1.3.1 (12w21a) |
+| 389 | Item Frame | item.frame | 1.4.2 (12w34a) |
+| 390 | Flower Pot | item.flowerPot | 1.4.2 (12w34a) |
+| 391 | Carrot | item.carrots | 1.4.2 (12w34a) |
+| 392 | Potato | item.potato | 1.4.2 (12w34a) |
+| 393 | Baked Potato | item.potatoBaked | 1.4.2 (12w34a) |
+| 394 | Poisonous Potato | item.potatoPoisonous | 1.4.2 (12w34a) |
+| 395 | Empty Map | item.emptyMap | 1.4.2 (12w34a) |
+| 396 | Golden Carrot | item.carrotGolden | 1.4.2 (12w34a) |
+| 397 | Mob Head | item.skull | 1.4.2 (12w36a) |
+| 398 | Carrot on a Stick | item.carrotOnAStick | 1.4.2 (12w36a) |
+| 399 | Nether Star | item.netherStar | 1.4.2 (12w36a) |
+| 400 | Pumpkin Pie | item.pumpkinPie | 1.4.2 (12w37a) |
+| 401 | Firework Rocket | item.fireworks | 1.4.6 (12w49a) |
+| 402 | Firework Star | item.fireworksCharge | 1.4.6 (12w49a) |
+| 403 | Enchanted Book | item.enchantedBook | 1.4.6 (12w49a) |
+| 404 | Redstone Comparator | item.comparator | 1.5 (13w01a) |
+| 405 | Nether Brick | item.netherbrick | 1.5 (13w01a) |
+| 406 | Nether Quartz | item.netherquartz | 1.5 (13w01a) |
+| 407 | Minecart with TNT | item.minecartTnt | 1.5 (13w02a) |
+| 408 | Minecart with Hopper | item.minecartHopper | 1.5 (13w03a) |
 | 2256 | Music Disc (C418 - 13) | item.record | Alpha v1.0.14 |
 | 2257 | Music Disc (C418 - cat) | item.record | Alpha v1.0.14 |
+| 2258 | Music Disc (C418 - blocks) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2259 | Music Disc (C418 - chirp) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2260 | Music Disc (C418 - far) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2261 | Music Disc (C418 - mall) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2262 | Music Disc (C418 - mellohi) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2263 | Music Disc (C418 - stal) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2264 | Music Disc (C418 - strad) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2265 | Music Disc (C418 - ward) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2266 | Music Disc (C418 - 11) | item.record | 1.0.0 (Beta 1.9 Prerelease 2) |
+| 2267 | Music Disc (C418 - wait) | item.record | 1.4.4 (1.4.3) |
 
-[^1]: From Release 1.3.1 onward, the translation key for diamonds is `item.diamond`.
+[^1]: From 12w21a (Release 1.3) onward, the translation key for diamonds is `item.diamond`.
 
 ## Removed blocks
 | ID | Block | Introduced in | Removed in |
@@ -299,3 +362,12 @@ This is a general reference for block and item IDs in vanilla Minecraft up to Re
 | 52 | Water Spawner | Indev 20100114 | Infdev 20100624 |
 | 53 | Lava Spawner | Indev 20100122 | Infdev 20100624 |
 | 55 | Gear | Indev 20100128 | Alpha v1.0.1 |
+
+## Removed items
+| ID | Item | Introduced in | Removed in |
+| --- | --- | --- | --- |
+| N/A | Studded Helmet | Indev 20091231-2 | Indev 20100110
+| N/A | Studded Chestplate | Indev 20091231-2 | Indev 20100110
+| N/A | Studded Leggings | Indev 20091231-2 | Indev 20100110
+| N/A | Studded Boots | Indev 20091231-2 | Indev 20100110
+| N/A | Quiver | Indev 20091231-2 | Indev 20100110


### PR DESCRIPTION
I have added all of the blocks and items from release 1.5.2 to the list as well as adding in when each block and item was added alongside some removed blocks and items from early versions of Minecraft.